### PR TITLE
Fix path to root directory

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -1,5 +1,5 @@
 location {LOCATION} {
-    alias {DESTDIR}/www;
+    alias {DESTDIR}/www/;
     if ($scheme = http) {
         rewrite ^ https://$server_name$request_uri? permanent;
     }


### PR DESCRIPTION
SInce installing Yunohost 2.4, I couldn't display the `index.html` page of a vanilla my_webapp installation (404). Nginx logs displayed this error:

> [error] 6345#0: *218 open() "/usr/share/nginx/htmlindex.php" failed (2: No such file or directory), client: 82.66.214.87, server: kemenaran.eu, request: "GET /index.html HTTP/1.1", host: "kemenaran.eu"

Steps to reproduce:

1. Install a fresh Debian 8 (tested on an OVH Kimsufi)
2. Install Yunohost 2.4 using the install script
3. Add a new custom domain (e.g. mydomain.com)
4. Install a my_webapp using this custom domain
5. Attempt to open `mydomain.com./index.html` in a web browser

Without this patch, the request fails with a 404 error.

Adding this trailing slash solves the issue. I'm not sure this is how it should be solved, but it fixed a painful issue for me :)