### PR TITLE
[fix] sshd service is not accessible anymore from "service"

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -102,4 +102,4 @@ sudo cp ../conf/php-fpm.conf "$phpfpm_conf"
 # Reload services
 sudo service php5-fpm reload
 sudo service nginx reload
-sudo service sshd reload
+sudo systemctl reload sshd

--- a/scripts/remove
+++ b/scripts/remove
@@ -32,7 +32,7 @@ sudo sed -i "/##-> ${app}/,/##<- ${app}/d" /etc/ssh/sshd_config
 # Reload services
 sudo service php5-fpm restart || true
 sudo service nginx reload || true
-sudo service sshd reload
+sudo systemctl reload sshd
 
 # Remove the user account
 id "$user" >/dev/null 2>&1 \

--- a/scripts/restore
+++ b/scripts/restore
@@ -78,4 +78,4 @@ sudo cp -a ./conf/php-fpm.conf "$phpfpm_conf"
 # Reload services
 sudo service php5-fpm reload || true
 sudo service nginx reload || true
-sudo service sshd reload
+sudo systemctl reload sshd

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -69,4 +69,4 @@ sudo cp ../conf/php-fpm.conf "$phpfpm_conf"
 # Reload services
 sudo service php5-fpm reload
 sudo service nginx reload
-sudo service sshd reload
+sudo systemctl reload sshd


### PR DESCRIPTION
Hello,

For wathever reason it's not possible to access the "sshd" service from the "service" command (but "service ssh" still works) thus making the installation fails. 

It's possible to access the "sshd" service from "systemctl". Testing on my cube and on a vm.

See https://dev.yunohost.org/issues/663