### PR TITLE
PasswordAuthentication yes in the upgrade script

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -140,6 +140,7 @@ Match User ${user}
   AllowTcpForwarding no
   PermitTunnel no
   X11Forwarding no
+  PasswordAuthentication yes
 ##<- ${app}" | tee -a /etc/ssh/sshd_config >/dev/null
 
 systemctl reload ssh


### PR DESCRIPTION
If authentication through is disabled in ssh, sftp fails. Adding PasswordAuthentication yes for the webapp user makes it work only for the weapp.

---
## Problem
- *Description of why you made this PR*

## Solution
- *And how you fix that*

## PR Status
Work finished. Package_check, basic tests and upgrade from last version OK.  
Could be reviewed and tested.

## Validation
*Minor decision*
- [ ] **Upgrade previous version** : 
- [ ] **Code review** : 
- [ ] **Approval (LGTM)** : 
- [ ] **Approval (LGTM)** : 
- [ ] **CI succeeded** : [![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/my_webapp_ynh%20PR21%20(Official_fork)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/my_webapp_ynh%20PR21%20(Official_fork)/)  
When the PR is mark as ready to merge, you have to wait for 3 days before really merge it.