### PR TITLE
Remove dependencies and reinstall them when changing php version

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -70,15 +70,15 @@ ram.runtime = "50M"
     [resources.apt]
     packages = "nginx"  # Kind of "dummy" value to be sure to have a non-empty dep list
     packages_from_raw_bash = """
-        if [[ "$database" == "mysql" ]]; then 
+        if [[ "$database" == "mysql" ]]; then
             echo "mariadb-server"
-            
+
             if [[ "$phpversion" != none ]]; then
                 echo "php${phpversion}-mysql"
             fi
         elif [[ "$database" == "postgresql" ]]; then
             echo "postgresql postgresql-contrib"
-            
+
             if [[ "$phpversion" != none ]]; then
                 echo "php${phpversion}-pgsql"
             fi

--- a/scripts/config
+++ b/scripts/config
@@ -127,7 +127,10 @@ ynh_app_config_apply() {
             ynh_secure_remove --file="$nginx_extra_conf_dir/php.conf"
         else
             ynh_add_config --template="nginx-php.conf" --destination="$nginx_extra_conf_dir/php.conf"
-            ynh_install_app_dependencies "php${phpversion}-fpm"
+            database=$(ynh_app_setting_get --app=$app --key=database)
+            dependencies="$(ynh_read_manifest -k "resources.apt.packages")"
+            dependencies_from_raw_bash=$(eval "$(ynh_read_manifest -k "resources.apt.packages_from_raw_bash")" | tr "\n" " ")
+            ynh_install_app_dependencies "$dependencies $dependencies_from_raw_bash"
             ynh_add_fpm_config --usage=$fpm_usage --footprint=$fpm_footprint --phpversion=$phpversion
             # ^ the helper takes care of ynh_app_setting_set the phpversion
         fi

--- a/scripts/config
+++ b/scripts/config
@@ -114,7 +114,7 @@ ynh_app_config_apply() {
     then
         ynh_app_setting_set --app=$app --key=phpversion --value="${old[phpversion]}"
         ynh_remove_fpm_config
-        # ^ the helper includes ynh_remove_app_dependencies
+        ynh_remove_app_dependencies
         YNH_PHP_VERSION=$phpversion
         # ^ ynh_add_config replaces __PHPVERSION__ by __PHP_YNH_VERSION__...
         ynh_app_setting_set --app=$app --key=phpversion --value="$phpversion"


### PR DESCRIPTION
## Problem

- When changing phpversion, we used to rely on `ynh_remove_fpm_config` helper to call `ynh_remove_app_dependencies`
- However, the behavior changed with packaging v2, `ynh_remove_fpm_config ` as I understand does not call this helper anymore.
- Also the package did not reinstall the dependencies when changing the php version. For example, if we installed mysql, php{NEWVERSION}-mysql were not installed

## Solution

- explicitly call `ynh_remove_app_dependencies`
- call `ynh_install_app_dependencies` with the dependencies

Resolves #131 

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)