### PR TITLE
fix restore on backup with mysql DB

### DIFF
--- a/scripts/backup
+++ b/scripts/backup
@@ -45,7 +45,7 @@ then
     ynh_print_info --message="Backing up the database..."
 
     if [ $database == "mysql" ]; then
-        ynh_mysql_dump_db --database="$db_name" > db.sql*
+        ynh_mysql_dump_db --database="$db_name" > db.sql
     elif [ $database == "postgresql" ]; then
         ynh_psql_dump_db --database="$db_name" > db.sql
     fi


### PR DESCRIPTION
## Problem

- [Restore fails if a mysql DB is used](https://forum.yunohost.org/t/erreur-restauration-sauvegarde-yunohost/27091)


## Solution

- fix the DB dump name

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)
