### PR TITLE
[Doc] Add PHP 8.3 in available versions

### DIFF
--- a/doc/DESCRIPTION.md
+++ b/doc/DESCRIPTION.md
@@ -2,7 +2,7 @@ This application allows you to easily install a custom Web application, providin
 
 It can also create a MySQL or PostgreSQL database - which will be backed up and restored with your application. The connection details will be stored in the file `db_access.txt` located in the root directory.
 
-PHP-FPM version can also be selected among `none`, `7.4`, `8.0`, `8.1` and `8.2`.
+PHP-FPM version can also be selected among `none`, `7.4`, `8.0`, `8.1`, `8.2` and `8.3`.
 
 **Once installed, go to the chosen URL to know the user, domain and port you will have to use for the SFTP access.** The password is one you chosen during the installation. Under the Web directory, you will see a `www` folder which contains the public files served by this app. You can put all the files of your custom Web application inside.
 

--- a/doc/DESCRIPTION_fr.md
+++ b/doc/DESCRIPTION_fr.md
@@ -2,7 +2,7 @@ Cette application vous permet d'installer facilement une application vide person
 
 Elle peut également créer une base de données MySQL ou PostgreSQL - qui sera sauvegardée et restaurée avec votre application. Les détails de connexion seront stockés dans le fichier `db_accesss.txt` situé dans le répertoire racine.
 
-La version de PHP-FPM peut aussi être choisie, parmi `none`, `7.4`, `8.0`, `8.1` et `8.2`.
+La version de PHP-FPM peut aussi être choisie, parmi `none`, `7.4`, `8.0`, `8.1`, `8.2` et `8.3`.
 
 **Une fois installé, rendez-vous sur l'URL choisie pour connaître l'utilisateur, le domaine et le port que vous devrez utiliser pour l'accès SFTP.** Le mot de passe est celui que vous avez choisi lors de l'installation. Sous le répertoire Web, vous verrez un dossier `www` qui contient les fichiers publics servis par cette application. Vous pouvez mettre tous les fichiers de votre application Web personnalisée à l'intérieur.
 


### PR DESCRIPTION
## Problem

- *PHP 8.3 is not listed in the available versions list.*

## Solution

- *Add PHP 8.3 in available versions*

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
