### PR TITLE
Add PHP 8.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It shall NOT be edited by hand.
 
 Custom Web app with SFTP access to serve static (HTML, CSS, JS) and PHP files
 
-[![Version: 1.0~ynh21](https://img.shields.io/badge/Version-1.0~ynh21-rgba(0,150,0,1)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/my_webapp/)
+[![Version: 1.0~ynh21](https://img.shields.io/badge/Version-1.0~ynh21-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/my_webapp/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/my_webapp"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>
@@ -20,8 +20,6 @@ Custom Web app with SFTP access to serve static (HTML, CSS, JS) and PHP files
 ## 📦 Developer info
 
 [![Automatic tests level](https://apps.yunohost.org/badge/cilevel/my_webapp)](https://ci-apps.yunohost.org/ci/apps/my_webapp/)
-
-🛠️ Upstream My Webapp repository: <>
 
 Pull request are welcome and should target the [`testing` branch](https://github.com/YunoHost-Apps/my_webapp_ynh/tree/testing).
 

--- a/doc/DESCRIPTION.md
+++ b/doc/DESCRIPTION.md
@@ -2,9 +2,9 @@ This application allows you to easily install an "empty" web application, in whi
 
 Files can be uploaded [via SFTP](https://yunohost.org/en/filezilla) or any other method of your chosing.
 
-During installation, you can also chose to initialize a MySQL or PostgreSQL database, which will be backed up and restored just like the other files in your application. The connection details will be stored in the file `db_access.txt` located in the root directory of the app.
+During installation, you can also choose to initialize a MySQL or PostgreSQL database, which will be backed up and restored just like the other files in your application. The connection details will be stored in the file `db_access.txt` located in the root directory of the app.
 
-PHP-FPM version can also be selected among (none), `7.4`, `8.0`, `8.1`, `8.2`, `8.3` and `8.4`.
+PHP-FPM version can also be selected among (none), `7.4`, `8.0`, `8.1`, `8.2`, `8.3`, `8.4` and `8.5`.
 
 **Once installed, go to the chosen URL to know the user, domain and port you will have to use for the SFTP access.** The password is the one specified during the installation. Under the app directory, you will see a `www` folder which contains the public files served by this app. You can put all the files of your custom web application inside.
 

--- a/doc/DESCRIPTION_fr.md
+++ b/doc/DESCRIPTION_fr.md
@@ -4,7 +4,7 @@ Les fichiers être déposé [via SFTP](https://yunohost.org/fr/filezilla) ou tou
 
 Lors de l'installation, il est aussi possible d'initialiser une base de données MySQL ou PostgreSQL, qui sera sauvegardée et restaurée avec le reste de l'application. Les détails de connexion seront stockés dans le fichier `db_accesss.txt` situé dans le répertoire racine.
 
-La version de PHP-FPM peut aussi être choisie, parmi (aucune), `7.4`, `8.0`, `8.1`, `8.2`, `8.3` et `8.4`.
+La version de PHP-FPM peut aussi être choisie, parmi (aucune), `7.4`, `8.0`, `8.1`, `8.2`, `8.3`, `8.4` et `8.5`.
 
 **Une fois installée, rendez-vous sur l'URL choisie pour connaître l'utilisateur, le domaine et le port que vous devrez utiliser pour l'accès SFTP.** Le mot de passe est celui que vous avez choisi lors de l'installation. Sous le répertoire Web, vous verrez un dossier `www` qui contient les fichiers publics servis par cette application. Vous pouvez mettre tous les fichiers de votre application Web personnalisée à l'intérieur.
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -50,7 +50,7 @@ ram.runtime = "50M"
     ask.en = "Choose a PHP version you want to use for your app"
     ask.fr = "Choisissez une version PHP que vous souhaitez utiliser pour votre application"
     type = "select"
-    choices = ["none", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]
+    choices = ["none", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4", "8.5"]
     default = "8.4"
 
     [install.database]

--- a/scripts/install
+++ b/scripts/install
@@ -13,7 +13,6 @@ source /usr/share/yunohost/helpers
 # RETRIEVE ARGUMENTS FROM THE MANIFEST
 #=================================================
 
-password=$YNH_APP_ARG_PASSWORD
 app_nb=$YNH_APP_INSTANCE_NUMBER
 ssh_port=$(grep "^Port" /etc/ssh/sshd_config | awk '{print $2}')
 

--- a/tests.toml
+++ b/tests.toml
@@ -27,6 +27,11 @@ test_format = 1.0
     only = ["install.subdir", "backup_restore", "upgrade" ]
     args.phpversion = "8.4"
 
+[85_test]
+
+    only = ["install.subdir", "backup_restore", "upgrade" ]
+    args.phpversion = "8.5"
+
 [none_test]
 
     args.phpversion = "none"


### PR DESCRIPTION
## Problem

PHP 8.5 couldn't be selected as PHP version.

## Solution

Add PHP 8.5 version.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
